### PR TITLE
Language support for AlliedSocietiesQuests.lua

### DIFF
--- a/Dailies/AlliedSocietiesQuests.lua
+++ b/Dailies/AlliedSocietiesQuests.lua
@@ -1,7 +1,7 @@
 --[=====[
 [[SND Metadata]]
 author: 'pot0to (https://ko-fi.com/pot0to) || Maintainer: Minnu (https://ko-fi.com/minnuverse)'
-version: 2.0.3
+version: 2.1.0
 description: Allied Societies Quests - Script for Dailies
 plugin_dependencies:
 - Questionable
@@ -182,245 +182,253 @@ for _, entry in ipairs(societyConfigKeys) do
     end
 end
 
+function GetNPCName(id)
+    return Excel.GetSheet("ENpcResident"):GetRow(id):GetProperty("Singular");
+end
+
+function GetPlaceName(id)
+    return Excel.GetSheet("PlaceName"):GetRow(id):GetProperty("Name");
+end
+
 AlliedSocietiesTable = {
     amaljaa = {
         alliedSocietyName = "Amalj'aa",
-        questGiver        = "Fibubb Gah",
+        questGiver        = GetNPCName(1005550), -- "Fibubb Gah"
         mainQuests        = { first = 1217, last = 1221 },
         dailyQuests       = { first = 1222, last = 1251, blackList = { [1245] = true } },
         x                 = 103.12,
         y                 = 15.05,
         z                 = -359.51,
         zoneId            = 146,
-        aetheryteName     = "Little Ala Mhigo",
+        aetheryteName     = GetPlaceName(313), -- "Little Ala Mhigo"
         expac             = "A Realm Reborn"
     },
     sylphs = {
         alliedSocietyName = "Sylphs",
-        questGiver        = "Tonaxia",
+        questGiver        = GetNPCName(1005561), -- "Tonaxia"
         mainQuests        = { first = 1252, last = 1256 },
         dailyQuests       = { first = 1257, last = 1286 },
         x                 = 46.41,
         y                 = 6.07,
         z                 = 252.91,
         zoneId            = 152,
-        aetheryteName     = "The Hawthorne Hut",
+        aetheryteName     = GetPlaceName(107), -- "The Hawthorne Hut"
         expac             = "A Realm Reborn"
     },
     kobolds = {
         alliedSocietyName = "Kobolds",
-        questGiver        = "789th Order Dustman Bo Bu",
+        questGiver        = GetNPCName(1005930), -- "789th Order Dustman Bo Bu"
         mainQuests        = { first = 1320, last = 1324 },
         dailyQuests       = { first = 1325, last = 1373 },
         x                 = 12.857726,
         y                 = 16.164295,
         z                 = -178.77,
         zoneId            = 180,
-        aetheryteName     = "Camp Overlook",
+        aetheryteName     = GetPlaceName(237), -- "Camp Overlook"
         expac             = "A Realm Reborn"
     },
     sahagin = {
         alliedSocietyName = "Sahagin",
-        questGiver        = "Houu",
+        questGiver        = GetNPCName(1005939), -- "Houu"
         mainQuests        = { first = 1374, last = 1378 },
         dailyQuests       = { first = 1380, last = 1409 },
         x                 = -244.53,
         y                 = -41.46,
         z                 = 52.75,
         zoneId            = 138,
-        aetheryteName     = "Aleport",
+        aetheryteName     = GetPlaceName(223), -- "Aleport"
         expac             = "A Realm Reborn"
     },
     ixal = {
         alliedSocietyName = "Ixal",
-        questGiver        = "Ehcatl Nine Manciple",
+        questGiver        = GetNPCName(1009201), -- "Ehcatl Nine Manciple"
         mainQuests        = { first = 1486, last = 1493 },
         dailyQuests       = { first = 1494, last = 1568 },
         x                 = 173.21,
         y                 = -5.37,
         z                 = 81.85,
         zoneId            = 154,
-        aetheryteName     = "Fallgourd Float",
+        aetheryteName     = GetPlaceName(140), -- "Fallgourd Float"
         expac             = "A Realm Reborn"
     },
     vanuvanu = {
         alliedSocietyName = "Vanu Vanu",
-        questGiver        = "Muna Vanu",
+        questGiver        = GetNPCName(1016089), -- "Muna Vanu"
         mainQuests        = { first = 2164, last = 2225 },
         dailyQuests       = { first = 2171, last = 2200 },
         x                 = -796.3722,
         y                 = -133.27,
         z                 = -404.35,
         zoneId            = 401,
-        aetheryteName     = "Ok' Zundu",
+        aetheryteName     = GetPlaceName(2123), -- "Ok' Zundu"
         expac             = "Heavensward"
     },
     vath = {
         alliedSocietyName = "Vath",
-        questGiver        = "Vath Keeneye",
+        questGiver        = GetNPCName(1016803), -- "Vath Keeneye"
         mainQuests        = { first = 2164, last = 2225 },
         dailyQuests       = { first = 2171, last = 2200 },
         x                 = 58.80,
         y                 = -48.00,
         z                 = -171.64,
         zoneId            = 398,
-        aetheryteName     = "Tailfeather",
+        aetheryteName     = GetPlaceName(2018), -- "Tailfeather"
         expac             = "Heavensward"
     },
     moogles = {
         alliedSocietyName = "Moogles",
-        questGiver        = "Mogek the Marvelous",
+        questGiver        = GetNPCName(1017171), -- "Mogek the Marvelous"
         mainQuests        = { first = 2320, last = 2327 },
         dailyQuests       = { first = 2290, last = 2319 },
         x                 = -335.28,
         y                 = 58.94,
         z                 = 316.30,
         zoneId            = 400,
-        aetheryteName     = "Zenith",
+        aetheryteName     = GetPlaceName(2046), -- "Zenith"
         expac             = "Heavensward"
     },
     kojin = {
         alliedSocietyName = "Kojin",
-        questGiver        = "Zukin",
+        questGiver        = GetNPCName(1024217), -- "Zukin"
         mainQuests        = { first = 2973, last = 2978 },
         dailyQuests       = { first = 2979, last = 3002 },
         x                 = 391.22,
         y                 = -119.59,
         z                 = -234.92,
         zoneId            = 613,
-        aetheryteName     = "Tamamizu",
+        aetheryteName     = GetPlaceName(2512), -- "Tamamizu"
         expac             = "Stormblood"
     },
     ananta = {
         alliedSocietyName = "Ananta",
-        questGiver        = "Eshana",
+        questGiver        = GetNPCName(1024773), -- "Eshana"
         mainQuests        = { first = 3036, last = 3041 },
         dailyQuests       = { first = 3043, last = 3069 },
         x                 = -26.91,
         y                 = 56.12,
         z                 = 233.53,
         zoneId            = 612,
-        aetheryteName     = "The Peering Stones",
+        aetheryteName     = GetPlaceName(2634), -- "The Peering Stones"
         expac             = "Stormblood"
     },
     namazu = {
         alliedSocietyName = "Namazu",
-        questGiver        = "Seigetsu the Enlightened",
+        questGiver        = GetNPCName(1025602), -- "Seigetsu the Enlightened"
         mainQuests        = { first = 3096, last = 3102 },
         dailyQuests       = { first = 3103, last = 3129 },
         x                 = -777.72,
         y                 = 127.81,
         z                 = 98.76,
         zoneId            = 622,
-        aetheryteName     = "Dhoro Iloh",
+        aetheryteName     = GetPlaceName(2850), -- "Dhoro Iloh"
         expac             = "Stormblood"
     },
     pixies = {
         alliedSocietyName = "Pixies",
-        questGiver        = "Uin Nee",
+        questGiver        = GetNPCName(1031809), -- "Uin Nee"
         mainQuests        = { first = 3683, last = 3688 },
         dailyQuests       = { first = 3689, last = 3716 },
         x                 = -453.69,
         y                 = 71.21,
         z                 = 573.54,
         zoneId            = 816,
-        aetheryteName     = "Lydha Lran",
+        aetheryteName     = GetPlaceName(3147), -- "Lydha Lran"
         expac             = "Shadowbringers"
     },
     qitari = {
         alliedSocietyName = "Qitari",
-        questGiver        = "Qhoterl Pasol",
+        questGiver        = GetNPCName(1032643), -- "Qhoterl Pasol"
         mainQuests        = { first = 3794, last = 3805 },
         dailyQuests       = { first = 3806, last = 3833 },
         x                 = 786.83,
         y                 = -45.82,
         z                 = -214.51,
         zoneId            = 817,
-        aetheryteName     = "Fanow",
+        aetheryteName     = GetPlaceName(3179), -- "Fanow"
         expac             = "Shadowbringers"
     },
     dwarves = {
         alliedSocietyName = "Dwarves",
-        questGiver        = "Regitt",
+        questGiver        = GetNPCName(1033712), -- "Regitt"
         mainQuests        = { first = 3896, last = 3901 },
         dailyQuests       = { first = 3902, last = 3929 },
         x                 = -615.48,
         y                 = 65.60,
         z                 = -423.82,
         zoneId            = 813,
-        aetheryteName     = "The Ostall Imperative",
+        aetheryteName     = GetPlaceName(3057), -- "The Ostall Imperative"
         expac             = "Shadowbringers"
     },
     arkosodara = {
         alliedSocietyName = "Arkasodara",
-        questGiver        = "Maru",
+        questGiver        = GetNPCName(1042257), -- "Maru"
         mainQuests        = { first = 4545, last = 4550 },
         dailyQuests       = { first = 4551, last = 4578 },
         x                 = -68.21,
         y                 = 39.99,
         z                 = 323.31,
         zoneId            = 957,
-        aetheryteName     = "Yedlihmad",
+        aetheryteName     = GetPlaceName(3880), -- "Yedlihmad"
         expac             = "Endwalker"
     },
     loporrits = {
         alliedSocietyName = "Loporrits",
-        questGiver        = "Managingway",
+        questGiver        = GetNPCName(1044403), -- "Managingway"
         mainQuests        = { first = 4681, last = 4686 },
         dailyQuests       = { first = 4687, last = 4714 },
         x                 = -201.27,
         y                 = -49.15,
         z                 = -273.8,
         zoneId            = 959,
-        aetheryteName     = "Bestways Burrow",
+        aetheryteName     = GetPlaceName(3966), -- "Bestways Burrow"
         expac             = "Endwalker"
     },
     omicrons = {
         alliedSocietyName = "Omicrons",
-        questGiver        = "Stigma-4",
+        questGiver        = GetNPCName(1041898), -- "Stigma-4"
         mainQuests        = { first = 4601, last = 4606 },
         dailyQuests       = { first = 4607, last = 4634 },
         x                 = 315.84,
         y                 = 481.99,
         z                 = 152.08,
         zoneId            = 960,
-        aetheryteName     = "Base Omicron",
+        aetheryteName     = GetPlaceName(3983), -- "Base Omicron"
         expac             = "Endwalker"
     },
     pelupleu = {
         alliedSocietyName = "Pelupelu",
-        questGiver        = "Yubli",
+        questGiver        = GetNPCName(1051643), -- "Yubli"
         mainQuests        = { first = 5193, last = 5198 },
         dailyQuests       = { first = 5199, last = 5226 },
         x                 = 770.89954,
         y                 = 12.846571,
         z                 = -261.0889,
         zoneId            = 1188,
-        aetheryteName     = "Dock Poga",
+        aetheryteName     = GetPlaceName(4595), -- "Dock Poga"
         expac             = "Dawntrail"
     },
     mamoolja = {
         alliedSocietyName = "Mamool Ja",
-        questGiver        = "Kageel Ja",
+        questGiver        = GetNPCName(1052560), -- "Kageel Ja"
         mainQuests        = { first = 5255, last = 5260 },
         dailyQuests       = { first = 5261, last = 5288 },
         x                 = 589.3,
         y                 = -142.9,
         z                 = 730.5,
         zoneId            = 1189,
-        aetheryteName     = "Mamook",
+        aetheryteName     = GetPlaceName(4625), -- "Mamook"
         expac             = "Dawntrail"
     },
     yokhuy = {
         alliedSocietyName = "Yok Huy",
-        questGiver        = "Vuyargur",
+        questGiver        = GetNPCName(1054635), -- "Vuyargur"
         mainQuests        = { first = 5330, last = 5335 },
         dailyQuests       = { first = 5336, last = 5363 },
         x                 = 495.40,
         y                 = 142.24,
         z                 = 784.53,
         zoneId            = 1187,
-        aetheryteName     = "Worlar's Echo",
+        aetheryteName     = GetPlaceName(4562), -- "Worlar's Echo"
         expac             = "Dawntrail"
     }
 }
@@ -505,7 +513,7 @@ for _, alliedSociety in ipairs(ToDoList) do
         end
 
         if not Svc.Condition[CharacterCondition.mounted] then
-            yield('/gaction "mount roulette"')
+            Actions.ExecuteGeneralAction(9) -- '/gaction "mount roulette"'
         end
 
         repeat


### PR DESCRIPTION
Added automatic language support.
Used Excel containing names in the game language. List of IDs retrieved via the [exd.camora.dev](https://exd.camora.dev/) site from the English language.
[ENpcResident](https://exd.camora.dev/sheet/ENpcResident)
[PlaceName](https://exd.camora.dev/sheet/PlaceName)

By name it can have several ids was possible, I took the first one each time, it is possible that certain ids would need to be tweaked.
Not tested in languages ​​other than French, tested the allied societies "Yok Huy", "Loporrits", "Pixies", and "Amalj'aa" and no problems.