### PR TITLE
fix crafters scrips

### DIFF
--- a/Crafters/CraftersScrips.lua
+++ b/Crafters/CraftersScrips.lua
@@ -668,9 +668,10 @@ function TurnIn()
                 yield("/wait 0.5")
             else
                 Dalamud.Log("[CraftersScrips] Selecting orange scrip item")
-                yield("/callback CollectablesShop true 15 0")
-                yield("/wait 1")
             end
+            
+            yield("/callback CollectablesShop true 15 0") -- submit
+            yield("/wait 1")
         end
     end
 end


### PR DESCRIPTION
`yield("/callback CollectablesShop true 15 0")` is the callback to hit the submit button.
`yield("/callback CollectablesShop true 12 1")` is the callback to select the purple scrip item
no callback is necessary to select the orange scrip item (selected by default upon opening the window)